### PR TITLE
Use shader lock additions

### DIFF
--- a/crates/cargo-gpu/src/main.rs
+++ b/crates/cargo-gpu/src/main.rs
@@ -78,10 +78,17 @@ fn main() {
 
     match cli.command {
         Command::Install(install) => {
+            log::debug!("installing with arguments: {install:#?}");
             let (_, _) = install.run();
         }
-        Command::Build(mut build) => build.run(),
-        Command::Toml(toml) => toml.run(),
+        Command::Build(mut build) => {
+            log::debug!("building with arguments: {build:#?}");
+            build.run()
+        }
+        Command::Toml(toml) => {
+            log::debug!("building by toml file with arguments: {toml:#?}");
+            toml.run()
+        }
         Command::Show(show) => show.run(),
         Command::DumpUsage => dump_full_usage_for_readme(),
     }

--- a/crates/cargo-gpu/src/show.rs
+++ b/crates/cargo-gpu/src/show.rs
@@ -2,8 +2,9 @@
 
 use crate::cache_dir;
 
+/// Show the computed source of the spirv-std dependency.
 #[derive(Clone, Debug, clap::Parser)]
-pub struct ShowSpirvSource {
+pub struct SpirvSourceDep {
     /// The location of the shader-crate to inspect to determine its spirv-std dependency.    
     #[clap(long, default_value = "./")]
     pub shader_crate: std::path::PathBuf,
@@ -15,7 +16,7 @@ pub enum Info {
     /// Displays the location of the cache directory
     CacheDirectory,
     /// The source location of spirv-std
-    SpirvSource(ShowSpirvSource),
+    SpirvSource(SpirvSourceDep),
 }
 
 /// `cargo gpu show`
@@ -34,7 +35,7 @@ impl Show {
             Info::CacheDirectory => {
                 println!("{}", cache_dir().display());
             }
-            Info::SpirvSource(ShowSpirvSource { shader_crate }) => {
+            Info::SpirvSource(SpirvSourceDep { shader_crate }) => {
                 let rust_gpu_source =
                     crate::spirv_source::SpirvSource::get_spirv_std_dep_definition(&shader_crate);
                 println!("{rust_gpu_source}");

--- a/crates/cargo-gpu/src/spirv_source.rs
+++ b/crates/cargo-gpu/src/spirv_source.rs
@@ -188,7 +188,7 @@ impl SpirvSource {
         log::debug!("Running `cargo tree` on {}", exec_path.display());
         let output_cargo_tree = std::process::Command::new("cargo")
             .current_dir(&exec_path)
-            .args(["tree", "--workspace", "--depth", "1", "--prefix", "none"])
+            .args(["tree", "--workspace", "--prefix", "none"])
             .output()
             .unwrap();
         assert!(

--- a/crates/cargo-gpu/src/spirv_source.rs
+++ b/crates/cargo-gpu/src/spirv_source.rs
@@ -24,7 +24,12 @@ pub enum SpirvSource {
     /// then the source of `rust-gpu` is `Git`.
     ///
     /// `(String, String)` is the repo source and revision hash or tag.
-    Git { url: String, rev: String },
+    Git {
+        /// URL of the repository
+        url: String,
+        /// Revision or "commitsh"
+        rev: String,
+    },
     /// If the shader specifies a version like:
     ///   `spirv-std = { path = "/path/to/rust-gpu" ... }`
     /// then the source of `rust-gpu` is `Path`.
@@ -40,9 +45,9 @@ impl core::fmt::Display for SpirvSource {
     )]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            SpirvSource::CratesIO(version) => f.write_str(version),
-            SpirvSource::Git { url, rev } => f.write_str(&format!("{url}+{rev}")),
-            SpirvSource::Path((a, b)) => f.write_str(&format!("{a}+{b}")),
+            Self::CratesIO(version) => f.write_str(version),
+            Self::Git { url, rev } => f.write_str(&format!("{url}+{rev}")),
+            Self::Path((a, b)) => f.write_str(&format!("{a}+{b}")),
         }
     }
 }

--- a/crates/cargo-gpu/src/toml.rs
+++ b/crates/cargo-gpu/src/toml.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use crate::{Cli, Command};
 
 /// `cargo gpu toml`
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 pub struct Toml {
     /// Path to a workspace or package Cargo.toml file.
     ///

--- a/crates/cargo-gpu/src/toml.rs
+++ b/crates/cargo-gpu/src/toml.rs
@@ -110,6 +110,12 @@ impl Toml {
             command: Command::Build(mut build),
         } = Cli::parse_from(parameters)
         {
+            // Ensure that the output directory is relative to the toml file
+            if build.output_dir.is_relative() {
+                let dir = path.parent().expect("no path parent");
+                build.output_dir = dir.join(build.output_dir);
+            }
+
             log::debug!("build: {build:?}");
             build.run();
         } else {

--- a/crates/spirv-builder-cli/src/main.rs
+++ b/crates/spirv-builder-cli/src/main.rs
@@ -93,6 +93,7 @@ fn main() {
         log::debug!("Calling `rust-gpu`'s `spirv-builder` library");
         builder.build().unwrap()
     };
+    log::debug!("found entry points: {entry_points:#?}");
 
     let dir = output_dir;
     let mut shaders = vec![];
@@ -100,6 +101,7 @@ fn main() {
         ModuleResult::MultiModule(modules) => {
             assert!(!modules.is_empty(), "No shader modules to compile");
             for (entry, filepath) in modules.into_iter() {
+                log::debug!("compiled {entry} {}", filepath.display());
                 shaders.push(ShaderModule::new(entry, filepath));
             }
         }


### PR DESCRIPTION
These are additions to the PR at 
* https://github.com/Rust-GPU/cargo-gpu/pull/27

In addition to one commit made directly to that PR branch, these changes include 
* clippy fixes
* sanitizing and canonicalizing the path used by `cargo tree` to find the `spirv-std` dependency
* removes "depth 1" from the `cargo tree` invocation as it was not discovering `spirv-std` in my use case
* when building via `toml`, the `output-dir` parameter is relative to the toml file parsed